### PR TITLE
Fix Nauvis crude oil generating with ice under it in Space Age

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -63,6 +63,13 @@ for _,tile in pairs(tiles) do
     end
 end
 
+-- Stop crude oil generating with ice tiles under it on Nauvis when Space Age is active
+if mods["space-age"] then
+    data.raw.explosion["aquilo-tiles-inner-explosion"].created_effect.action_delivery.target_effects[1].tile_collision_mask.layers["shallow_resource"] = true
+    data.raw.explosion["aquilo-tiles-outer-explosion"].created_effect.action_delivery.target_effects[1].tile_collision_mask.layers["shallow_resource"] = true
+    data.raw.explosion["aquilo-tiles-outer-explosion"].created_effect.action_delivery.target_effects[2].tile_collision_mask.layers["shallow_resource"] = true
+end
+
 -- If we have Cargo Ships, we have offshore oil; remove the land deposits from water accordingly
 if mods["cargo-ships"] then
     local crude_mask = collision_mask_util.get_mask(data.raw.resource["crude-oil"])

--- a/info.json
+++ b/info.json
@@ -7,6 +7,7 @@
   "description": "Ore patches now spill over into the sea as submerged variants. Dredge them up with new floating hardware, and build deeper into the blue with water-placeable, removable refined concrete.",
   "dependencies": [
     "base >= 2.0.34",
+    "(?) space-age",
     "dredgeworks-graphics >= 0.1.1",
     "? cargo-ships",
     "? rso-mod",


### PR DESCRIPTION
This was really bothering me, cause it looks rather silly. Even with Cargo Ships it would still spawn ice around crude oil nodes that generate *near* water. So, I dug into the space-age prototypes to find out how in the heck those tiles actually get placed, and came up with a fix!